### PR TITLE
Update PLSS2LL.R

### DIFF
--- a/R/PLSS2LL.R
+++ b/R/PLSS2LL.R
@@ -18,7 +18,7 @@ formatPLSS <- function(p, type='SN') {
     p.r <- paste0(p.r, collapse = '0')
     
     # add 'SN to section number and pad single digit section numbers
-    p.s <- ifelse((p$s[i] > 9), paste0('SN', p$s[i]), paste0('SN', 0, p$s[i]))
+    p.s <- ifelse(as.numeric(p$s[i] > 9), paste0('SN', p$s[i]), paste0('SN', 0, p$s[i]))
     #p.s <- paste0('SN', p$s[i])
     
     # replace NA -> '' IN Q and QQ sections


### PR DESCRIPTION
added as.numeric() to the condition. I have a column of section numbers coded as characters. This did not stop the function from running, but I got weird results (the resulting plssid code was not in good format I guess). I'm not sure how this miss-specified operators work, but for example "14" > 9 returns FALSE.

Note: this function could also be vectorized, but it runs pretty fast already.