### PR TITLE
LL2PLSS: Return NULL object instead of error

### DIFF
--- a/R/PLSS2LL.R
+++ b/R/PLSS2LL.R
@@ -194,6 +194,9 @@ formatPLSS <- function(p, type = 'SN') {
 #'
 #'    curl::has_internet() &
 #'     require(sp)) {
+#'     
+#'     # BLM PLSS API needs a long timeout
+#'     options(timeout = 60000)
 #'
 #'     # create coordinates
 #'     x <- -115.3823
@@ -203,7 +206,8 @@ formatPLSS <- function(p, type = 'SN') {
 #'     p.plss <- LL2PLSS(x, y)
 #'
 #'     # plot geometry
-#'     plot(p.plss$geom)
+#'     if (length(p.plss$geom) > 0)
+#'      plot(p.plss$geom)
 #' }
 #' }
 #' 
@@ -371,7 +375,10 @@ LL2PLSS <- function(x, y, returnlevel= 'I') {
 #' 
 #' if(requireNamespace("curl") &
 #'    curl::has_internet()) {
-#'
+#'    
+#'   # BLM PLSS API needs a long timeout
+#'   options(timeout = 60000)
+#'   
 #'   # create some data
 #'   d <- data.frame(
 #'     id = 1:3,

--- a/R/PLSS2LL.R
+++ b/R/PLSS2LL.R
@@ -265,10 +265,13 @@ LL2PLSS <- function(x, y, returnlevel= 'I') {
     # check for invalid result:
     # * reversed coordinates in x,y
     # * nothing returned by the API
-    if(is.null(res$features$geometry.rings))
-      stop("invalid geometry specification, check coordinate XY order (longitude: X, latitude: Y)")
-
-    # attempt to extract PLSS geometry
+    if(is.null(res$features$geometry.rings)) {
+      message("invalid geometry specification, check coordinate XY order (longitude: X, latitude: Y)")
+      # return "NULL" result
+      return(list(geom=SpatialPolygons(list()), plss=NULL))
+    }
+    
+  # attempt to extract PLSS geometry
     geom <- SpatialPolygons(list(Polygons(list(Polygon(res$features$geometry.rings[[1]][1,, ])), ID = .polyID)))
     srid <- res$features$geometry.spatialReference.wkid
     proj4string(geom) <- paste0('+init=epsg:', srid)

--- a/man/LL2PLSS.Rd
+++ b/man/LL2PLSS.Rd
@@ -34,6 +34,9 @@ if(requireNamespace("curl") &
 
    curl::has_internet() &
     require(sp)) {
+    
+    # BLM PLSS API needs a long timeout
+    options(timeout = 60000)
 
     # create coordinates
     x <- -115.3823
@@ -43,7 +46,8 @@ if(requireNamespace("curl") &
     p.plss <- LL2PLSS(x, y)
 
     # plot geometry
-    plot(p.plss$geom)
+    if (length(p.plss$geom) > 0)
+     plot(p.plss$geom)
 }
 }
 

--- a/man/PLSS2LL.Rd
+++ b/man/PLSS2LL.Rd
@@ -26,7 +26,10 @@ This function expects that the dataframe will have a 'plssid' column generated b
 
 if(requireNamespace("curl") &
    curl::has_internet()) {
-
+   
+  # BLM PLSS API needs a long timeout
+  options(timeout = 60000)
+  
   # create some data
   d <- data.frame(
     id = 1:3,

--- a/tests/testthat/test-PLSS2LL.R
+++ b/tests/testthat/test-PLSS2LL.R
@@ -50,8 +50,10 @@ test_that("formatPLSS, PLSS2LL, LL2PLSS works", {
     # position of NA inputs is preserved
     expect_true(is.na(res$plssid[3]))
 
-    # expect error: lng/lat reversed
-    expect_error(LL2PLSS(res$lat[1], res$lon[1]))
+    # expect null object and message: lng/lat reversed
+    expect_message({badres <- LL2PLSS(res$lat[1], res$lon[1])})
+    expect_true(inherits(badres[[1]], 'SpatialPolygons'))
+    expect_true(is.null(badres[[2]]))
 
     # expect silent: LL2PLSS now vectorized (warnings because of NA DROPPED from SpatialPolygons)
     expect_warning({res2 <- LL2PLSS(res$lon, res$lat)})


### PR DESCRIPTION
RE: CRAN error in examples

I think we can just use the NULL object pattern instead of the `stop()`, with a message and an "empty" result" instead. 