### PR TITLE
mucomp402-srsbm

### DIFF
--- a/R/sampleRasterStackByMU.R
+++ b/R/sampleRasterStackByMU.R
@@ -272,6 +272,10 @@ sampleRasterStackByMU <- function(mu,
   
   # assemble into data.frame
   d.mu <- ldply(d.mu)
+  if (length(l.mu) == 1) {
+    d.mu <- data.frame(.id = as.character(mu.set), 
+                       d.mu, stringsAsFactors = FALSE)
+  }
   colnames(d.mu)[1] <- mu.col
   
   ## unspool polygon sample IDs when no samples were collected


### PR DESCRIPTION
- `mu.col` can be dropped from result when `ldply()` called on a list of length 1 (one level of `mu.set`)? If there was a prior protection for this it was removed/broken in recent changes with v4 of the report (my bad)